### PR TITLE
Fix normalization for mod and val properties

### DIFF
--- a/lib/normalize/normalize.js
+++ b/lib/normalize/normalize.js
@@ -47,7 +47,8 @@ function revealDep(dep, entity) {
     var tech = dep.tech,
         block = dep.block,
         elems = dep.elems || dep.elem,
-        mods = dep.mods || dep.mod;
+        mods = dep.mods || dep.mod,
+        val = dep.val;
 
     if((mods || tech) && !elems && !block) {
         elems = entity.elem;
@@ -59,7 +60,7 @@ function revealDep(dep, entity) {
         tech: revealItem('tech', tech),
         block: revealItem('block', block),
         elems: revealElems(elems),
-        mods: revealMods(mods)
+        mods: revealMods(mods, val)
     };
 }
 
@@ -80,22 +81,21 @@ function revealElems(elems) {
     }
 }
 
-function revealMods(mods) {
+function revealMods(mods, val) {
+    if(_.isString(mods)) {
+        return [val ? {mod: mods, val: val} : {mod: mods}];
+    }
     mods = utils.wrapIntoArray(mods);
 
     return _(mods)
-        .map(revealMod_)
+        .map(revealModsObj_)
         .flattenDeep()
         .value();
 
-    function revealMod_(mod) {
-        return _.isString(mod) && {mod: utils.createMapEntry(mod, true)} || revealModsObj_(mod);
-    }
-
     function revealModsObj_(mods) {
         return _.map(mods, function(modVal, modName) {
-            return !_.isArray(modVal) && {mod: utils.createMapEntry(modName, modVal)}
-                || _.map(modVal, function(val) {return {mod: utils.createMapEntry(modName, val)};});
+            return _.map([].concat(modVal), function(val) {return {mod: modName, val: val};})
+                .concat({mod: modName});
         });
     }
 }

--- a/lib/normalize/normalize.js
+++ b/lib/normalize/normalize.js
@@ -22,7 +22,7 @@ var normalize = module.exports = function(dep, entity) {
     function normalize_(revealedDep) {
         var normalized = [];
 
-        if(_.isArray(dep.elems)) {
+        if(dep.elems) {
             normalized.push(combine(revealedDep.tech, revealedDep.block, revealedDep.elems));
 
             revealedDep.mods.length && normalized.push(combine(revealedDep.tech, revealedDep.block, revealedDep.mods));

--- a/test/normalize/normalize.js
+++ b/test/normalize/normalize.js
@@ -1,0 +1,38 @@
+var normalize = require('../../lib/normalize/normalize');
+
+describe('normalize', function() {
+    function test(entity, result) {
+        normalize(entity).should.be.eql(result ? result : [entity]);
+    }
+
+    it('should not change simple entities', function() {
+        test({block: 'b'});
+        test({block: 'b', elem: 'e'});
+        test({block: 'b', mod: 'm'});
+        test({block: 'b', mod: 'm', val: true});
+        test({block: 'b', mod: 'm', val: 'v'});
+        test({block: 'b', elem: 'e', mod: 'm'});
+        test({block: 'b', elem: 'e', mod: 'm', val: true});
+        test({block: 'b', elem: 'e', mod: 'm', val: 'v'});
+    });
+
+    it('should normalize mods correctly', function() {
+        test({block: 'b', mods: {m: 'v'}}, [{block: 'b', mod: 'm', val: 'v'}, {block: 'b', mod: 'm'}, {block: 'b'}]);
+        test({block: 'b', mods: {m1: true, m2: ['v1', 'v2']}},
+            [{block: 'b', mod: 'm1', val: true}, {block: 'b', mod: 'm1'},
+             {block: 'b', mod: 'm2', val: 'v1'}, {block: 'b', mod: 'm2', val: 'v2'}, {block: 'b', mod: 'm2'},
+             {block: 'b'}]);
+    });
+
+    it('should normalize elems correctly', function() {
+        test({block: 'b', elems: 'e'}, [{block: 'b', elem: 'e'}, {block: 'b'}]);
+        test({block: 'b', elems: ['e1', 'e2']}, [{block: 'b', elem: 'e1'}, {block: 'b', elem: 'e2'}, {block: 'b'}]);
+        test({block: 'b', elems: 'e', mod: 'm'}, [{block: 'b', elem: 'e'}, {block: 'b', mod: 'm'}, {block: 'b'}]);
+        test({block: 'b', elems: {elem: 'e', mod: 'm'}},
+            [{block: 'b', elem: 'e', mod: 'm'}, {block: 'b'}]);
+        test({block: 'b', elems: {elem: 'e', mod: 'm', val: 'v'}},
+            [{block: 'b', elem: 'e', mod: 'm', val: 'v'}, {block: 'b'}]);
+        test({block: 'b', elems: {elem: 'e', mods: {m: 'v'}}}, [{block: 'b', elem: 'e', mod: 'm', val: 'v'},
+            {block: 'b', elem: 'e', mod: 'm'}, {block: 'b', elem: 'e'}, {block: 'b'}]);
+    });
+});


### PR DESCRIPTION
``` javascript
var normalize = require('./lib/normalize');
var result = normalize({
    mustDeps: {block: 'b', mod: 'm', val: 'v'}
});
result[0].mustDeps
// [ { block: 'b', mod: { m: true } } ]
```

Three issues here:
- `val` is ignored, `mod` handled as a boolean;
- `object` is not a valid value for `mod` (both for deps and deps-old);
- entity `{block: 'b', mod: 'm'}` is absent:

``` javascript
var difference = require('./lib/difference')
var result = difference({
    mustDeps: {block: 'b', mods: {m: 'v'}}
}, {
    mustDeps: {block: 'b', mod: 'm'}
})
result[0].mustDeps
// [ { block: 'b', mod: { m: true } } ]
```

After patch:

``` javascript
require('./lib/normalize')({mustDeps: {block: 'b', mod: 'm', val: 'v'}})[0].mustDeps
// [ { block: 'b', mod: 'm' }, { block: 'b', mod: 'm', val: 'v' } ]
```
